### PR TITLE
Typed deep object validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ var descriptor = {
 
 And supply a source object of `{roles: ["admin", "user"]}` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
 
+#### Values
+
+The `values` property can be used with the `array` or `object` type for validating all values of the container. 
+It may be an `object` or `array` containing validation rules. For example:
+
+```javascript
+var descriptor = {
+  urls: {
+    type: "array", required: true,
+    values: {type: "url"}
+  }
+}
+```
+
+Note that `values` is expanded to `fields`, see [deep rules](#deep-rules).
+
 #### Transform
 
 Sometimes it is necessary to transform a value before validation, possibly to coerce the value or to sanitize it in some way. To do this add a `transform` function to the validation rule. The property is transformed prior to validation and re-assigned to the source object to mutate the value of the property in place.

--- a/tests/deep.spec.js
+++ b/tests/deep.spec.js
@@ -1,0 +1,81 @@
+const expect = require('expect.js');
+const Schema = require('../index');
+
+describe('deep', () => {
+  it('deep array specific validation', (done) => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        fields: {
+          0: [{type: 'string'}],
+          1: [{type: 'string'}],
+        },
+      },
+    }).validate({
+      v: [1, 'b'],
+    }, (errors) => {
+      expect(errors.length).to.be(1);
+      expect(errors[0].message).to.be('v.0 is not a string');
+      done();
+    });
+  });
+
+  it('deep array all values validation', (done) => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        values: [{type: 'string'}],
+      },
+    }).validate({
+      v: [1, 2, 'c'],
+    }, (errors) => {
+      expect(errors.length).to.be(2);
+      expect(errors[0].message).to.be('v.0 is not a string');
+      expect(errors[1].message).to.be('v.1 is not a string');
+      done();
+    });
+  });
+
+  it('deep object specific validation', (done) => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'object',
+        fields: {
+          a: [{type: 'string'}],
+          b: [{type: 'string'}],
+        },
+      },
+    }).validate({
+      v: {
+        'a': 1,
+        'b': 'c',
+      },
+    }, (errors) => {
+      expect(errors.length).to.be(1);
+      expect(errors[0].message).to.be('v.a is not a string');
+      done();
+    });
+  });
+
+  it('deep object all values validation', (done) => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'object',
+        values: [{type: 'string'}],
+      },
+    }).validate({
+      v: {
+        'a': 1,
+        'b': 'c',
+      },
+    }, (errors) => {
+      expect(errors.length).to.be(1);
+      expect(errors[0].message).to.be('v.a is not a string');
+      done();
+    });
+  });
+});

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -6,3 +6,4 @@ require('./string.spec');
 require('./url.spec');
 require('./date.spec');
 require('./messages.spec');
+require('./deep.spec');


### PR DESCRIPTION
Adds a `values` property that allows to add validation rules to all elements of an `array` or `object`.