### PR TITLE
fix errors is null

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -101,7 +101,7 @@ function asyncSerialArray(arr, func, callback) {
   const arrLength = arr.length;
 
   function next(errors) {
-    if (errors.length) {
+    if (errors && errors.length) {
       callback(errors);
       return;
     }


### PR DESCRIPTION
when the validate value type is object, the errors return by the deep validate might be null.