### PR TITLE
Validator supports Promise

### DIFF
--- a/__tests__/promise.spec.js
+++ b/__tests__/promise.spec.js
@@ -1,0 +1,143 @@
+import Schema from '../src/';
+
+describe('validator', () => {
+  it('works', (done) => {
+    new Schema({
+      v: [{
+        validator(rule, value) {
+          return Promise.reject(new Error('e1'));
+        },
+      }, {
+        validator(rule, value) {
+          return Promise.reject(new Error('e2'));
+        },
+      }],
+      v2: [{
+        validator(rule, value) {
+          return Promise.reject(new Error('e3'));
+        },
+      }],
+    }).validate({
+      v: 2,
+    }, (errors) => {
+      expect(errors.length).toBe(3);
+      expect(errors[0].message).toBe('e1');
+      expect(errors[1].message).toBe('e2');
+      expect(errors[2].message).toBe('e3');
+      done();
+    });
+  });
+
+  it('first works', (done) => {
+    new Schema({
+      v: [{
+        validator(rule, value) {
+          return Promise.reject(new Error('e1'));
+        },
+      }, {
+        validator(rule, value) {
+          return Promise.reject(new Error('e2'));
+        },
+      }],
+      v2: [{
+        validator(rule, value) {
+          return Promise.reject(new Error('e3'));
+        },
+      }],
+    }).validate({
+      v: 2,
+      v2: 1,
+    }, {
+      first: true,
+    }, (errors) => {
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toBe('e1');
+      done();
+    });
+  });
+
+  describe('firstFields', () => {
+    it('works for true', (done) => {
+      new Schema({
+        v: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e1'));
+          },
+        }, {
+          validator(rule, value) {
+            return Promise.reject(new Error('e2'));
+          },
+        }],
+
+        v2: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e3'));
+          },
+        }],
+        v3: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e4'));
+          },
+        }, {
+          validator(rule, value) {
+            return Promise.reject(new Error('e5'));
+          },
+        }],
+      }).validate({
+        v: 1,
+        v2: 1,
+        v3: 1,
+      }, {
+        firstFields: true,
+      }, (errors) => {
+        expect(errors.length).toBe(3);
+        expect(errors[0].message).toBe('e1');
+        expect(errors[1].message).toBe('e3');
+        expect(errors[2].message).toBe('e4');
+        done();
+      });
+    });
+
+    it('works for array', (done) => {
+      new Schema({
+        v: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e1'));
+          },
+        }, {
+          validator(rule, value) {
+            return Promise.reject(new Error('e2'));
+          },
+        }],
+
+        v2: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e3'));
+          },
+        }],
+        v3: [{
+          validator(rule, value) {
+            return Promise.reject(new Error('e4'));
+          },
+        }, {
+          validator(rule, value) {
+            return Promise.reject(new Error('e5'));
+          },
+        }],
+      }).validate({
+        v: 1,
+        v2: 1,
+        v3: 1,
+      }, {
+        firstFields: ['v'],
+      }, (errors) => {
+        expect(errors.length).toBe(4);
+        expect(errors[0].message).toBe('e1');
+        expect(errors[1].message).toBe('e3');
+        expect(errors[2].message).toBe('e4');
+        expect(errors[3].message).toBe('e5');
+        done();
+      });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -211,8 +211,11 @@ Schema.prototype = {
         }
       }
 
-      rule.validator(
+      const res = rule.validator(
         rule, data.value, cb, data.source, options);
+      if (res && res.then) {
+        res.then(() => cb(), e => cb(e));
+      }
     }, (results) => {
       complete(results);
     });


### PR DESCRIPTION
Validator 支持返回一个 Promise

```JavaScript
/* eslint no-console:0 */

import Schema from 'async-validator';

const schema = new Schema({
  name: {
    type: 'string',
    required: true,
    min: 5,
    max: 10,
  },
  address: {
    type: 'object',
    required: true,
    fields: {
      province: {
        type: 'string',
        required: true,
        min: 4,
      },
      city: {
        type: 'string',
        message: 'custom message',
        min: 5,
      },
      async: {
        validator(rule, value) {
          return new Promise((resolve, reject) => {
            setTimeout(() => {
              resolve(rule.message);
            }, 100);
          })
        },
        message: 'address async fails',
      },
    },
  },
  async: {
    validator(rule, value) {
        return new Promise((resolve, reject) => {
          setTimeout(() => {
            reject(new Error('一个测试错误'));
          }, 100);
        })
    },
    message: 'async fails',
  },
});

schema.validate({
  name: 2,
  address: {
    city: 2,
  },
  async: '2',
}, (errors, fields) => {
  console.log('errors');
  console.log(errors);
  console.log('fields');
  console.log(fields);
});

console.log('end');

```