### PR TITLE
change error.field -> rule.field

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -160,12 +160,12 @@ export function asyncMap(objArr, option, func, callback) {
 export function complementError(rule) {
   return (oe) => {
     if (oe && oe.message) {
-      oe.field = oe.field || rule.fullField;
+      oe.field = rule.field || rule.fullField;
       return oe;
     }
     return {
       message: oe,
-      field: oe.field || rule.fullField,
+      field: rule.field || rule.fullField,
     };
   };
 }


### PR DESCRIPTION
Actually when we have to do some i18n process on the error message, we have to inject the proper field name into the message but not the field name in code (such as `password` VS `密码`).
In async-validator developer can assign the correct field name with the `fullField` rule property, but when the field validation is failed the error return should contain the original field name that we can use it to do some other things what it is not do now.