### PR TITLE
fix options typos and remove 'fieldFirst'. Fixes #18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ Schema.prototype = {
 
         errors = errors.map(complementError(rule));
 
-        if ((options.first || options.fieldFirst) && errors.length) {
+        if (options.first && errors.length) {
           errorFields[rule.field] = 1;
           return doIt(errors);
         }


### PR DESCRIPTION
这个应该是`firstFields`的错误字吧。而且看了一下代码，这个地方不应该有这个判断，`firstFields`的功能在`util.js`里都处理掉了。容易误解，所以去掉了。