### PR TITLE
Add maximum length condition for e-mail address

### DIFF
--- a/src/rule/type.js
+++ b/src/rule/type.js
@@ -48,7 +48,7 @@ const types = {
     return typeof (value) === 'function';
   },
   email(value) {
-    return typeof (value) === 'string' && !!value.match(pattern.email);
+    return typeof (value) === 'string' && !!value.match(pattern.email) && value.length < 255;
   },
   url(value) {
     return typeof (value) === 'string' && !!value.match(pattern.url);


### PR DESCRIPTION
According to the RFC, an e-mail address can have a maximum of 254 characters.

> Since addresses that do not fit in those fields are not normally useful, the upper limit on address lengths should normally be considered to be 254.

[Source: RFC Errata Report](http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690)

_Further information:_
[Stackoverflow: What is the maximum length of a valid email address?](https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address)

Instead of referring to the `max` condition manually, the global maximum length makes sure that all e-mail addresses are conform to the RFC specification.

This pull request adds this condition.

Off-topic: Other positive side effects are, that some database fields with a 255 VARCHAR limit, which is quite common for an e-mail address, won't be exceeded.