### PR TITLE
修复自定义fullField无法生效的问题

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -160,12 +160,12 @@ export function asyncMap(objArr, option, func, callback) {
 export function complementError(rule) {
   return (oe) => {
     if (oe && oe.message) {
-      oe.field = oe.field || rule.fullField;
+      oe.field = oe.field || rule.field;
       return oe;
     }
     return {
       message: oe,
-      field: oe.field || rule.fullField,
+      field: oe.field || rule.field,
     };
   };
 }


### PR DESCRIPTION
这个位置把返回数据的key设定为自定义显示的fullField，导致FormItem找不到对应key的errors，所以不显示红色错误提示