### PR TITLE
fix: date兼容timestamp

### DIFF
--- a/__tests__/date.spec.js
+++ b/__tests__/date.spec.js
@@ -31,4 +31,18 @@ describe('date', () => {
       done();
     });
   });
+
+  it('required works for "timestamp"', (done) => {
+    new Schema({
+      v: {
+        type: 'date',
+        required: true,
+      },
+    }).validate({
+      v: 1530374400000,
+    }, (errors) => {
+      expect(errors).toBe(null);
+      done();
+    });
+  });
 });

--- a/src/validator/date.js
+++ b/src/validator/date.js
@@ -12,9 +12,17 @@ function date(rule, value, callback, source, options) {
     }
     rules.required(rule, value, source, errors, options);
     if (!isEmptyValue(value)) {
-      rules.type(rule, value, source, errors, options);
-      if (value) {
-        rules.range(rule, value.getTime(), source, errors, options);
+      let dateObject;
+
+      if (typeof value === 'number') {
+        dateObject = new Date(value);
+      } else {
+        dateObject = value;
+      }
+
+      rules.type(rule, dateObject, source, errors, options);
+      if (dateObject) {
+        rules.range(rule, dateObject.getTime(), source, errors, options);
       }
     }
   }


### PR DESCRIPTION
- 当value是一个`timestamp`时，调用`getTime()`函数会报错
- 前后端传递date时通常使用`timestamp`
