### PR TITLE
Enum validates `false` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ If the `len` property is combined with the `min` and `max` range properties, `le
 
 #### Enumerable
 
+> Since version 3.0.0 if you want to validate the values `0` or `false` inside `enum` types, you have to include them explicitly.
+
 To validate a value from a list of possible values use the `enum` type with a `enum` property listing the valid values for the field, for example:
 
 ```javascript
@@ -418,6 +420,18 @@ const fields = {
 ```js
 var Schema = require('async-validator');
 Schema.warning = function(){};
+```
+
+### How to check if it is `true`
+
+Use `enum` type passing `true` as option.
+
+```js
+{
+  type: 'enum',
+  enum: [true],
+  message: '',
+}
 ```
 
 ## Test Case

--- a/__tests__/enum.spec.js
+++ b/__tests__/enum.spec.js
@@ -1,0 +1,18 @@
+import Schema from '../src/';
+
+describe('enum', () => {
+  it('run validation on `false`', (done) => {
+    new Schema({
+      v: {
+        type: 'enum',
+        enum: [true],
+      },
+    }).validate({
+      v: false,
+    }, (errors) => {
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toBe('v must be one of true');
+      done();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-validator",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "validate form asynchronous",
   "keywords": [
     "validator",

--- a/src/validator/enum.js
+++ b/src/validator/enum.js
@@ -22,7 +22,7 @@ function enumerable(rule, value, callback, source, options) {
       return callback();
     }
     rules.required(rule, value, source, errors, options);
-    if (value) {
+    if (value !== undefined) {
       rules[ENUM](rule, value, source, errors, options);
     }
   }


### PR DESCRIPTION
To validate `true` we have to do a kludge to compare Strings instead of Boolean values:

```js
{
  transform: value => String(value),
  type: 'enum',
  enum: ['true'],
  message: '',
}
```

With this pull request, we can do it directly and a little more intuitively (the best would be to pass a `true` directly, instead of an enum with 1 value, but this solves the problem fast):

```js
{
  type: 'enum',
  enum: [true],
  message: '',
}
```

The problem would be if someone is using enum and accepting `null`, `undefined`, `0` or `false` without listing this in the validation array.

But `null` and `undefined` are not checked already (`isEmptyValue` returns true for both and skips validation). 

`0` and `false` are values, and should be included in the `enum` array of valid values if they are valid. Therefore this is the right way. Poor written code might break, but the fix is quite easy, so I can include a section in the documentation if the PR is acceptable.

**How to validate only true** - https://github.com/yiminghe/async-validator/issues/89

