### PR TITLE
Add displayField property, to display a custom field name in messages

### DIFF
--- a/__tests__/any.spec.js
+++ b/__tests__/any.spec.js
@@ -34,6 +34,25 @@ const testRequiredErrorFor = value => done => {
   );
 };
 
+const testRequiredErrorWithDisplayFieldFor = value => done => {
+  new Schema({
+    v: {
+      required: true,
+      type: 'string',
+      displayField: 'V',
+    },
+  }).validate(
+    {
+      v: value,
+    },
+    errors => {
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toBe('V is required');
+      done();
+    },
+  );
+};
+
 describe('any', () => {
   it('allows null', testNoErrorsFor(null));
   it('allows undefined', testNoErrorsFor(undefined));
@@ -44,4 +63,12 @@ describe('any', () => {
   it('allows objects', testNoErrorsFor({}));
   it('rejects undefined when required', testRequiredErrorFor(undefined));
   it('rejects null when required', testRequiredErrorFor(null));
+  it(
+    'rejects undefined with display field when required',
+    testRequiredErrorWithDisplayFieldFor(undefined),
+  );
+  it(
+    'rejects null with display field when required',
+    testRequiredErrorWithDisplayFieldFor(null),
+  );
 });

--- a/__tests__/array.spec.js
+++ b/__tests__/array.spec.js
@@ -18,6 +18,24 @@ describe('array', () => {
     );
   });
 
+  it('works for type with display field', done => {
+    new Schema({
+      v: {
+        type: 'array',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not an array');
+        done();
+      },
+    );
+  });
+
   it('works for type and required', done => {
     new Schema({
       v: {
@@ -31,6 +49,25 @@ describe('array', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is not an array');
+        done();
+      },
+    );
+  });
+
+  it('works for type and required with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not an array');
         done();
       },
     );
@@ -70,6 +107,25 @@ describe('array', () => {
     );
   });
 
+  it('works for empty array with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: [],
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for undefined array', done => {
     new Schema({
       v: {
@@ -88,6 +144,25 @@ describe('array', () => {
     );
   });
 
+  it('works for undefined array with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: undefined,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for null array', done => {
     new Schema({
       v: {
@@ -101,6 +176,25 @@ describe('array', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is required');
+        done();
+      },
+    );
+  });
+
+  it('works for null array with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: null,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
         done();
       },
     );

--- a/__tests__/date.spec.js
+++ b/__tests__/date.spec.js
@@ -19,6 +19,25 @@ describe('date', () => {
     );
   });
 
+  it('required works for undefined with display field', done => {
+    new Schema({
+      v: {
+        type: 'date',
+        required: true,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: undefined,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('required works for ""', done => {
     new Schema({
       v: {
@@ -32,6 +51,25 @@ describe('date', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is not a date');
+        done();
+      },
+    );
+  });
+
+  it('required works for "" with display field', done => {
+    new Schema({
+      v: {
+        type: 'date',
+        required: true,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not a date');
         done();
       },
     );

--- a/__tests__/deep.spec.js
+++ b/__tests__/deep.spec.js
@@ -23,6 +23,52 @@ describe('deep', () => {
     );
   });
 
+  it('deep array specific validation with local display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+        fields: {
+          0: [{ type: 'string', displayField: 'V0' }],
+          1: [{ type: 'string' }],
+        },
+      },
+    }).validate(
+      {
+        v: [1, 'b'],
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V0 is not a string');
+        done();
+      },
+    );
+  });
+
+  it('deep array specific validation with parent display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'array',
+        displayField: 'V',
+        fields: {
+          0: [{ type: 'string' }],
+          1: [{ type: 'string' }],
+        },
+      },
+    }).validate(
+      {
+        v: [1, 'b'],
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not a string');
+        done();
+      },
+    );
+  });
+
   it('deep object specific validation', done => {
     new Schema({
       v: {
@@ -48,6 +94,58 @@ describe('deep', () => {
     );
   });
 
+  it('deep object specific validation with local display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'object',
+        displayField: 'V',
+        fields: {
+          a: [{ type: 'string', displayField: 'VA' }],
+          b: [{ type: 'string' }],
+        },
+      },
+    }).validate(
+      {
+        v: {
+          a: 1,
+          b: 'c',
+        },
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('VA is not a string');
+        done();
+      },
+    );
+  });
+
+  it('deep object specific validation with parent display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'object',
+        displayField: 'V',
+        fields: {
+          a: [{ type: 'string' }],
+          b: [{ type: 'string' }],
+        },
+      },
+    }).validate(
+      {
+        v: {
+          a: 1,
+          b: 'c',
+        },
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not a string');
+        done();
+      },
+    );
+  });
+
   describe('defaultField', () => {
     it('deep array all values validation', done => {
       new Schema({
@@ -64,6 +162,48 @@ describe('deep', () => {
           expect(errors.length).toBe(2);
           expect(errors[0].message).toBe('v.0 is not a string');
           expect(errors[1].message).toBe('v.1 is not a string');
+          done();
+        },
+      );
+    });
+
+    it('deep array all values validation with local display field', done => {
+      new Schema({
+        v: {
+          required: true,
+          type: 'array',
+          displayField: 'V',
+          defaultField: [{ type: 'string', displayField: 'VV' }],
+        },
+      }).validate(
+        {
+          v: [1, 2, 'c'],
+        },
+        errors => {
+          expect(errors.length).toBe(2);
+          expect(errors[0].message).toBe('VV is not a string');
+          expect(errors[1].message).toBe('VV is not a string');
+          done();
+        },
+      );
+    });
+
+    it('deep array all values validation with parent display field', done => {
+      new Schema({
+        v: {
+          required: true,
+          type: 'array',
+          displayField: 'V',
+          defaultField: [{ type: 'string' }],
+        },
+      }).validate(
+        {
+          v: [1, 2, 'c'],
+        },
+        errors => {
+          expect(errors.length).toBe(2);
+          expect(errors[0].message).toBe('V is not a string');
+          expect(errors[1].message).toBe('V is not a string');
           done();
         },
       );
@@ -142,6 +282,52 @@ describe('deep', () => {
         errors => {
           expect(errors.length).toBe(1);
           expect(errors[0].message).toBe('v.a is not a string');
+          done();
+        },
+      );
+    });
+
+    it('deep object all values validation with local display field', done => {
+      new Schema({
+        v: {
+          required: true,
+          type: 'object',
+          displayField: 'V',
+          defaultField: [{ type: 'string', displayField: 'VA' }],
+        },
+      }).validate(
+        {
+          v: {
+            a: 1,
+            b: 'c',
+          },
+        },
+        errors => {
+          expect(errors.length).toBe(1);
+          expect(errors[0].message).toBe('VA is not a string');
+          done();
+        },
+      );
+    });
+
+    it('deep object all values validation with parent display field', done => {
+      new Schema({
+        v: {
+          required: true,
+          type: 'object',
+          displayField: 'V',
+          defaultField: [{ type: 'string' }],
+        },
+      }).validate(
+        {
+          v: {
+            a: 1,
+            b: 'c',
+          },
+        },
+        errors => {
+          expect(errors.length).toBe(1);
+          expect(errors[0].message).toBe('V is not a string');
           done();
         },
       );

--- a/__tests__/enum.spec.js
+++ b/__tests__/enum.spec.js
@@ -1,18 +1,40 @@
 import Schema from '../src/';
 
 describe('enum', () => {
-  it('run validation on `false`', (done) => {
+  it('run validation on `false`', done => {
     new Schema({
       v: {
         type: 'enum',
         enum: [true],
       },
-    }).validate({
-      v: false,
-    }, (errors) => {
-      expect(errors.length).toBe(1);
-      expect(errors[0].message).toBe('v must be one of true');
-      done();
-    });
+    }).validate(
+      {
+        v: false,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('v must be one of true');
+        done();
+      },
+    );
+  });
+
+  it('run validation on `false` with dislpay field', done => {
+    new Schema({
+      v: {
+        type: 'enum',
+        enum: [true],
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: false,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V must be one of true');
+        done();
+      },
+    );
   });
 });

--- a/__tests__/messages.spec.js
+++ b/__tests__/messages.spec.js
@@ -31,6 +31,38 @@ describe('messages', () => {
     );
   });
 
+  it('can call messages with display field', done => {
+    const messages = {
+      required(f) {
+        return `${f} required!`;
+      },
+    };
+    const schema = new Schema({
+      v: {
+        required: true,
+        displayField: 'V',
+      },
+      v2: {
+        type: 'array',
+        displayField: 'V2',
+      },
+    });
+    schema.messages(messages);
+    schema.validate(
+      {
+        v: '',
+        v2: '1',
+      },
+      errors => {
+        expect(errors.length).toBe(2);
+        expect(errors[0].message).toBe('V required!');
+        expect(errors[1].message).toBe('V2 is not an array');
+        expect(Object.keys(messages).length).toBe(1);
+        done();
+      },
+    );
+  });
+
   it('can use options.messages', done => {
     const messages = {
       required(f) {
@@ -57,6 +89,40 @@ describe('messages', () => {
         expect(errors.length).toBe(2);
         expect(errors[0].message).toBe('v required!');
         expect(errors[1].message).toBe('v2 is not an array');
+        expect(Object.keys(messages).length).toBe(1);
+        done();
+      },
+    );
+  });
+
+  it('can use options.messages with display field', done => {
+    const messages = {
+      required(f) {
+        return `${f} required!`;
+      },
+    };
+    const schema = new Schema({
+      v: {
+        required: true,
+        displayField: 'V',
+      },
+      v2: {
+        type: 'array',
+        displayField: 'V2',
+      },
+    });
+    schema.validate(
+      {
+        v: '',
+        v2: '1',
+      },
+      {
+        messages,
+      },
+      errors => {
+        expect(errors.length).toBe(2);
+        expect(errors[0].message).toBe('V required!');
+        expect(errors[1].message).toBe('V2 is not an array');
         expect(Object.keys(messages).length).toBe(1);
         done();
       },

--- a/__tests__/number.spec.js
+++ b/__tests__/number.spec.js
@@ -18,6 +18,24 @@ describe('number', () => {
     );
   });
 
+  it('works with display field', done => {
+    new Schema({
+      v: {
+        type: 'number',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '1',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not a number');
+        done();
+      },
+    );
+  });
+
   it('works for no-required', done => {
     new Schema({
       v: {
@@ -64,6 +82,25 @@ describe('number', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is required');
+        done();
+      },
+    );
+  });
+
+  it('works for required with display field', done => {
+    new Schema({
+      v: {
+        type: 'number',
+        required: true,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: undefined,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
         done();
       },
     );

--- a/__tests__/required.spec.js
+++ b/__tests__/required.spec.js
@@ -75,6 +75,24 @@ describe('required', () => {
     );
   });
 
+  it('works for string required=true with display field', done => {
+    new Schema({
+      v: {
+        required,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for string required=false', done => {
     new Schema({
       v: {
@@ -140,6 +158,24 @@ describe('required', () => {
     );
   });
 
+  it('works for null required=true with display field', done => {
+    new Schema({
+      v: {
+        required,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: null,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for null required=false', done => {
     new Schema({
       v: {
@@ -168,6 +204,24 @@ describe('required', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is required');
+        done();
+      },
+    );
+  });
+
+  it('works for undefined required=true with display field', done => {
+    new Schema({
+      v: {
+        required,
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: undefined,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
         done();
       },
     );

--- a/__tests__/string.spec.js
+++ b/__tests__/string.spec.js
@@ -35,6 +35,25 @@ describe('string', () => {
     );
   });
 
+  it('works for empty string with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'string',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for undefined string', done => {
     new Schema({
       v: {
@@ -53,6 +72,25 @@ describe('string', () => {
     );
   });
 
+  it('works for undefined string with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'string',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: undefined,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
+        done();
+      },
+    );
+  });
+
   it('works for null string', done => {
     new Schema({
       v: {
@@ -66,6 +104,25 @@ describe('string', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is required');
+        done();
+      },
+    );
+  });
+
+  it('works for null string with display field', done => {
+    new Schema({
+      v: {
+        required: true,
+        type: 'string',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: null,
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is required');
         done();
       },
     );

--- a/__tests__/url.spec.js
+++ b/__tests__/url.spec.js
@@ -33,11 +33,12 @@ describe('url', () => {
     );
   });
 
-  it('works for required empty string', done => {
+  it('works for required empty string with display field', done => {
     new Schema({
       v: {
         type: 'url',
         required: true,
+        displayField: 'V',
       },
     }).validate(
       {
@@ -45,7 +46,7 @@ describe('url', () => {
       },
       errors => {
         expect(errors.length).toBe(1);
-        expect(errors[0].message).toBe('v is required');
+        expect(errors[0].message).toBe('V is required');
         done();
       },
     );
@@ -143,6 +144,24 @@ describe('url', () => {
       errors => {
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('v is not a valid url');
+        done();
+      },
+    );
+  });
+
+  it('works for type not a valid url with display field', done => {
+    new Schema({
+      v: {
+        type: 'url',
+        displayField: 'V',
+      },
+    }).validate(
+      {
+        v: 'http://www.taobao.com/abc?abc=%23&b=  a~c#abc    ',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('V is not a valid url');
         done();
       },
     );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,6 +52,7 @@ declare module 'async-validator' {
     defaultField?: { type: RuleType }; // 'object' or 'array' containing validation rules
     transform?: (value: any) => any;
     message?: string;
+    displayField?: string;
     asyncValidator?: (
       rule: Rules,
       value: any,

--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ Schema.prototype = {
 
         function addFullfield(key, schema) {
           return {
+            displayField: rule.displayField,
             ...schema,
             fullField: `${rule.fullField}.${key}`,
           };
@@ -184,7 +185,10 @@ Schema.prototype = {
                 errors = [
                   options.error(
                     rule,
-                    format(options.messages.required, rule.field),
+                    format(
+                      options.messages.required,
+                      rule.displayField || rule.field,
+                    ),
                   ),
                 ];
               } else {
@@ -248,7 +252,10 @@ Schema.prototype = {
           }
         }
         if (res && res.then) {
-          res.then(() => cb(), e => cb(e));
+          res.then(
+            () => cb(),
+            e => cb(e),
+          );
         }
       },
       results => {
@@ -262,7 +269,8 @@ Schema.prototype = {
     }
     if (
       typeof rule.validator !== 'function' &&
-      (rule.type && !validators.hasOwnProperty(rule.type))
+      rule.type &&
+      !validators.hasOwnProperty(rule.type)
     ) {
       throw new Error(format('Unknown rule type %s', rule.type));
     }

--- a/src/rule/enum.js
+++ b/src/rule/enum.js
@@ -19,7 +19,7 @@ function enumerable(rule, value, source, errors, options) {
     errors.push(
       util.format(
         options.messages[ENUM],
-        rule.fullField,
+        rule.displayField || rule.fullField,
         rule[ENUM].join(', '),
       ),
     );

--- a/src/rule/pattern.js
+++ b/src/rule/pattern.js
@@ -22,7 +22,7 @@ function pattern(rule, value, source, errors, options) {
         errors.push(
           util.format(
             options.messages.pattern.mismatch,
-            rule.fullField,
+            rule.displayField || rule.fullField,
             value,
             rule.pattern,
           ),
@@ -34,7 +34,7 @@ function pattern(rule, value, source, errors, options) {
         errors.push(
           util.format(
             options.messages.pattern.mismatch,
-            rule.fullField,
+            rule.displayField || rule.fullField,
             value,
             rule.pattern,
           ),

--- a/src/rule/range.js
+++ b/src/rule/range.js
@@ -45,22 +45,34 @@ function range(rule, value, source, errors, options) {
   if (len) {
     if (val !== rule.len) {
       errors.push(
-        util.format(options.messages[key].len, rule.fullField, rule.len),
+        util.format(
+          options.messages[key].len,
+          rule.displayField || rule.fullField,
+          rule.len,
+        ),
       );
     }
   } else if (min && !max && val < rule.min) {
     errors.push(
-      util.format(options.messages[key].min, rule.fullField, rule.min),
+      util.format(
+        options.messages[key].min,
+        rule.displayField || rule.fullField,
+        rule.min,
+      ),
     );
   } else if (max && !min && val > rule.max) {
     errors.push(
-      util.format(options.messages[key].max, rule.fullField, rule.max),
+      util.format(
+        options.messages[key].max,
+        rule.displayField || rule.fullField,
+        rule.max,
+      ),
     );
   } else if (min && max && (val < rule.min || val > rule.max)) {
     errors.push(
       util.format(
         options.messages[key].range,
-        rule.fullField,
+        rule.displayField || rule.fullField,
         rule.min,
         rule.max,
       ),

--- a/src/rule/required.js
+++ b/src/rule/required.js
@@ -17,7 +17,12 @@ function required(rule, value, source, errors, options, type) {
     (!source.hasOwnProperty(rule.field) ||
       util.isEmptyValue(value, type || rule.type))
   ) {
-    errors.push(util.format(options.messages.required, rule.fullField));
+    errors.push(
+      util.format(
+        options.messages.required,
+        rule.displayField || rule.fullField,
+      ),
+    );
   }
 }
 

--- a/src/rule/type.js
+++ b/src/rule/type.js
@@ -102,7 +102,7 @@ function type(rule, value, source, errors, options) {
       errors.push(
         util.format(
           options.messages.types[ruleType],
-          rule.fullField,
+          rule.displayField || rule.fullField,
           rule.type,
         ),
       );
@@ -110,7 +110,11 @@ function type(rule, value, source, errors, options) {
     // straight typeof check
   } else if (ruleType && typeof value !== rule.type) {
     errors.push(
-      util.format(options.messages.types[ruleType], rule.fullField, rule.type),
+      util.format(
+        options.messages.types[ruleType],
+        rule.displayField || rule.fullField,
+        rule.type,
+      ),
     );
   }
 }

--- a/src/rule/whitespace.js
+++ b/src/rule/whitespace.js
@@ -13,7 +13,12 @@ import * as util from '../util';
  */
 function whitespace(rule, value, source, errors, options) {
   if (/^\s+$/.test(value) || value === '') {
-    errors.push(util.format(options.messages.whitespace, rule.fullField));
+    errors.push(
+      util.format(
+        options.messages.whitespace,
+        rule.displayField || rule.fullField,
+      ),
+    );
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -2,8 +2,7 @@
 
 const formatRegExp = /%[sdj%]/g;
 
-export let warning = () => {
-};
+export let warning = () => {};
 
 // don't print warning message when in production env or node runtime
 if (


### PR DESCRIPTION
Allow the user to provide a `displayField` property to provide a localized field name in error messages.