### PR TITLE
fix: a promise was rejected with a non-error

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -188,8 +188,8 @@ export function asyncMap(objArr, option, func, callback) {
         callback(results);
         return results.length
           ? reject(new AsyncValidationError(
-              errors,
-              convertFieldsError(errors)
+              results,
+              convertFieldsError(results)
             ))
           : resolve();
       }

--- a/src/util.js
+++ b/src/util.js
@@ -146,13 +146,24 @@ function flattenObjArr(objArr) {
   return ret;
 }
 
+export class AsyncValidationError extends Error {
+  constructor(errors, fields) {
+    super('Async Validation Error');
+    this.errors = errors;
+    this.fields = fields;
+  }
+}
+
 export function asyncMap(objArr, option, func, callback) {
   if (option.first) {
     const pending = new Promise((resolve, reject) => {
       const next = errors => {
         callback(errors);
         return errors.length
-          ? reject({ errors, fields: convertFieldsError(errors) })
+          ? reject(new AsyncValidationError(
+              errors,
+              convertFieldsError(errors)
+            ))
           : resolve();
       };
       const flattenArr = flattenObjArr(objArr);
@@ -176,7 +187,10 @@ export function asyncMap(objArr, option, func, callback) {
       if (total === objArrLength) {
         callback(results);
         return results.length
-          ? reject({ errors: results, fields: convertFieldsError(results) })
+          ? reject(new AsyncValidationError(
+              errors,
+              convertFieldsError(errors)
+            ))
           : resolve();
       }
     };


### PR DESCRIPTION
fix: a promise was rejected with a non-error

https://eslint.org/docs/rules/prefer-promise-reject-errors

Saved backwards compatibility with return structure fields

fix #226