### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Validate form asynchronous. A variation of https://github.com/freeformsystems/as
 
 ## Install
 
-```
+```bash
 npm i async-validator
 ```
 
@@ -33,7 +33,7 @@ npm i async-validator
 
 Basic usage involves defining a descriptor, assigning it to a schema and passing the object to be validated and a callback function to the `validate` method of the schema:
 
-```javascript
+```js
 import schema from 'async-validator';
 const descriptor = {
   name: {
@@ -77,7 +77,7 @@ validator.validate({ name: "muji", age: 16 }).then(() => {
 
 ### Validate
 
-```javascript
+```js
 function(source, [options], callback): Promise
 ```
 
@@ -104,7 +104,7 @@ no more validation rules of the same field are processed.  `true` means all fiel
 
 Rules may be functions that perform validation.
 
-```javascript
+```js
 function(rule, value, callback, source, options)
 ```
 
@@ -117,7 +117,7 @@ function(rule, value, callback, source, options)
 
 The options passed to `validate` or `asyncValidate` are passed on to the validation functions so that you may reference transient data (such as model references) in validation functions. However, some option names are reserved; if you use these properties of the options object they are overwritten. The reserved properties are `messages`, `exception` and `error`.
 
-```javascript
+```js
 import schema from 'async-validator';
 const descriptor = {
   name(rule, value, callback, source, options) {
@@ -142,7 +142,7 @@ validator.validate({name: "Firstname"}, (errors, fields) => {
 
 It is often useful to test against multiple validation rules for a single field, to do so make the rule an array of objects, for example:
 
-```javascript
+```js
 const descriptor = {
   email: [
     {type: "string", required: true, pattern: schema.pattern.email},
@@ -200,7 +200,7 @@ If the `len` property is combined with the `min` and `max` range properties, `le
 
 To validate a value from a list of possible values use the `enum` type with a `enum` property listing the valid values for the field, for example:
 
-```javascript
+```js
 const descriptor = {
   role: {type: "enum", enum: ['admin', 'user', 'guest']}
 }
@@ -217,7 +217,7 @@ You may wish to sanitize user input instead of testing for whitespace, see [tran
 
 If you need to validate deep object properties you may do so for validation rules that are of the `object` or `array` type by assigning nested rules to a `fields` property of the rule.
 
-```javascript
+```js
 const descriptor = {
   address: {
     type: "object", required: true,
@@ -239,7 +239,7 @@ Note that if you do not specify the `required` property on the parent rule it is
 
 Deep rule validation creates a schema for the nested rules so you can also specify the `options` passed to the `schema.validate()` method.
 
-```javascript
+```js
 const descriptor = {
   address: {
     type: "object", required: true, options: {first: true},
@@ -261,7 +261,7 @@ validator.validate({ address: {} })
 
 The parent rule is also validated so if you have a set of rules such as:
 
-```javascript
+```js
 const descriptor = {
   roles: {
     type: "array", required: true, len: 3,
@@ -281,7 +281,7 @@ And supply a source object of `{roles: ["admin", "user"]}` then two errors will 
 The `defaultField` property can be used with the `array` or `object` type for validating all values of the container.
 It may be an `object` or `array` containing validation rules. For example:
 
-```javascript
+```js
 const descriptor = {
   urls: {
     type: "array", required: true,
@@ -296,7 +296,7 @@ Note that `defaultField` is expanded to `fields`, see [deep rules](#deep-rules).
 
 Sometimes it is necessary to transform a value before validation, possibly to coerce the value or to sanitize it in some way. To do this add a `transform` function to the validation rule. The property is transformed prior to validation and re-assigned to the source object to mutate the value of the property in place.
 
-```javascript
+```js
 import schema from 'async-validator';
 const descriptor = {
   name: {
@@ -322,18 +322,18 @@ Depending upon your application requirements, you may need i18n support or you m
 
 The easiest way to achieve this is to assign a `message` to a rule:
 
-```javascript
+```js
 {name:{type: "string", required: true, message: "Name is required"}}
 ```
 
 Message can be any type, such as jsx format.
 
-```javascript
+```js
 {name:{type: "string", required: true, message: "<b>Name is required</b>"}}
 ```
 
 Message can also be a function, e.g. if you use vue-i18n:
-```javascript
+```js
 {name:{type: "string", required: true, message: () => this.$t( 'name is required' )}}
 ```
 
@@ -341,7 +341,7 @@ Potentially you may require the same schema validation rules for different langu
 
 In this scenario you could just provide your own messages for the language and assign it to the schema:
 
-```javascript
+```js
 import schema from 'async-validator';
 const cn = {
   required: '%s 必填',
@@ -438,14 +438,14 @@ Use `enum` type passing `true` as option.
 
 ## Test Case
 
-```
+```bash
 npm test
 npm run chrome-test
 ```
 
 ## Coverage
 
-```
+```bash
 npm run coverage
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ const descriptor = {
   age: {
     type: 'number',
     asyncValidator: (rule, value) => {
-        return new Promise((resolve, reject) => {
-          if (value < 18) {
-            reject('too young');  // reject with error message
-          } else {
-            resolve();
-          }
-        });
-      }
+      return new Promise((resolve, reject) => {
+        if (value < 18) {
+          reject('too young');  // reject with error message
+        } else {
+          resolve();
+        }
+      });
+    }
   }
 };
 const validator = new schema(descriptor);
@@ -146,12 +146,14 @@ It is often useful to test against multiple validation rules for a single field,
 const descriptor = {
   email: [
     { type: 'string', required: true, pattern: schema.pattern.email },
-    { validator(rule, value, callback, source, options) {
-      const errors = [];
-      // test if email address already exists in a database
-      // and add a validation error to the errors array if it does
-      return errors;
-    }}
+    { 
+      validator(rule, value, callback, source, options) {
+        const errors = [];
+        // test if email address already exists in a database
+        // and add a validation error to the errors array if it does
+        return errors;
+      }
+    }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ const descriptor = {
   name(rule, value, callback, source, options) {
     const errors = [];
     if (!/^[a-z0-9]+$/.test(value)) {
-      errors.push(
-        new Error(
-          util.format('%s must be lowercase alphanumeric characters',
-            rule.field)));
+      errors.push(new Error(
+        util.format('%s must be lowercase alphanumeric characters', rule.field),
+      ));
     }
     return errors;
   }

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ const descriptor = {
   }
 };
 const validator = new schema(descriptor);
-validator.validate({name: 'muji'}, (errors, fields) => {
-  if(errors) {
+validator.validate({ name: 'muji' }, (errors, fields) => {
+  if (errors) {
     // validation failed, errors is an array of all errors
     // fields is an object keyed by field name with an array of
     // errors per field
@@ -122,7 +122,7 @@ import schema from 'async-validator';
 const descriptor = {
   name(rule, value, callback, source, options) {
     const errors = [];
-    if(!/^[a-z0-9]+$/.test(value)) {
+    if (!/^[a-z0-9]+$/.test(value)) {
       errors.push(
         new Error(
           util.format('%s must be lowercase alphanumeric characters',
@@ -132,8 +132,8 @@ const descriptor = {
   }
 }
 const validator = new schema(descriptor);
-validator.validate({name: 'Firstname'}, (errors, fields) => {
-  if(errors) {
+validator.validate({ name: 'Firstname' }, (errors, fields) => {
+  if (errors) {
     return handleErrors(errors, fields);
   }
   // validation passed
@@ -145,8 +145,8 @@ It is often useful to test against multiple validation rules for a single field,
 ```js
 const descriptor = {
   email: [
-    {type: 'string', required: true, pattern: schema.pattern.email},
-    {validator(rule, value, callback, source, options) {
+    { type: 'string', required: true, pattern: schema.pattern.email },
+    { validator(rule, value, callback, source, options) {
       const errors = [];
       // test if email address already exists in a database
       // and add a validation error to the errors array if it does
@@ -202,7 +202,7 @@ To validate a value from a list of possible values use the `enum` type with a `e
 
 ```js
 const descriptor = {
-  role: {type: 'enum', enum: ['admin', 'user', 'guest']}
+  role: { type: 'enum', enum: ['admin', 'user', 'guest'] }
 }
 ```
 
@@ -222,12 +222,12 @@ const descriptor = {
   address: {
     type: 'object', required: true,
     fields: {
-      street: {type: 'string', required: true},
-      city: {type: 'string', required: true},
-      zip: {type: 'string', required: true, len: 8, message: 'invalid zip'}
+      street: { type: 'string', required: true },
+      city: { type: 'string', required: true },
+      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' }
     }
   },
-  name: {type: 'string', required: true}
+  name: { type: 'string', required: true }
 }
 const validator = new schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
@@ -242,14 +242,14 @@ Deep rule validation creates a schema for the nested rules so you can also speci
 ```js
 const descriptor = {
   address: {
-    type: 'object', required: true, options: {first: true},
+    type: 'object', required: true, options: { first: true },
     fields: {
-      street: {type: 'string', required: true},
-      city: {type: 'string', required: true},
-      zip: {type: 'string', required: true, len: 8, message: 'invalid zip'}
+      street: { type: 'string', required: true },
+      city: { type: 'string', required: true },
+      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' }
     }
   },
-  name: {type: 'string', required: true}
+  name: { type: 'string', required: true }
 }
 const validator = new schema(descriptor);
 
@@ -266,15 +266,15 @@ const descriptor = {
   roles: {
     type: 'array', required: true, len: 3,
     fields: {
-      0: {type: 'string', required: true},
-      1: {type: 'string', required: true},
-      2: {type: 'string', required: true}
+      0: { type: 'string', required: true },
+      1: { type: 'string', required: true },
+      2: { type: 'string', required: true }
     }
   }
 }
 ```
 
-And supply a source object of `{roles: ['admin', 'user']}` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
+And supply a source object of `{ roles: ['admin', 'user'] }` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
 
 #### defaultField
 
@@ -285,7 +285,7 @@ It may be an `object` or `array` containing validation rules. For example:
 const descriptor = {
   urls: {
     type: 'array', required: true,
-    defaultField: {type: 'url'}
+    defaultField: { type: 'url' }
   }
 }
 ```
@@ -308,7 +308,7 @@ const descriptor = {
   }
 }
 const validator = new schema(descriptor);
-const source = {name: ' user  '};
+const source = { name: ' user  ' };
 validator.validate(source)
   .then(() => assert.equal(source.name, 'user'));
 ```
@@ -323,18 +323,18 @@ Depending upon your application requirements, you may need i18n support or you m
 The easiest way to achieve this is to assign a `message` to a rule:
 
 ```js
-{name:{type: 'string', required: true, message: 'Name is required'}}
+{ name: { type: 'string', required: true, message: 'Name is required' } }
 ```
 
 Message can be any type, such as jsx format.
 
 ```js
-{name:{type: 'string', required: true, message: '<b>Name is required</b>'}}
+{ name: { type: 'string', required: true, message: '<b>Name is required</b>' } }
 ```
 
 Message can also be a function, e.g. if you use vue-i18n:
 ```js
-{name:{type: 'string', required: true, message: () => this.$t( 'name is required' )}}
+{ name: { type: 'string', required: true, message: () => this.$t( 'name is required' ) } }
 ```
 
 Potentially you may require the same schema validation rules for different languages, in which case duplicating the schema rules for each language does not make sense.
@@ -346,7 +346,7 @@ import schema from 'async-validator';
 const cn = {
   required: '%s 必填',
 };
-const descriptor = {name:{type: 'string', required: true}};
+const descriptor = { name: { type: 'string', required: true } };
 const validator = new schema(descriptor);
 // deep merge with defaultMessages
 validator.messages(cn);

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Basic usage involves defining a descriptor, assigning it to a schema and passing
 
 ```javascript
 import schema from 'async-validator';
-var descriptor = {
+const descriptor = {
   name: {
     type: "string",
     required: true,
@@ -54,7 +54,7 @@ var descriptor = {
       }
   }
 };
-var validator = new schema(descriptor);
+const validator = new schema(descriptor);
 validator.validate({name: "muji"}, (errors, fields) => {
   if(errors) {
     // validation failed, errors is an array of all errors
@@ -119,9 +119,9 @@ The options passed to `validate` or `asyncValidate` are passed on to the validat
 
 ```javascript
 import schema from 'async-validator';
-var descriptor = {
+const descriptor = {
   name(rule, value, callback, source, options) {
-    var errors = [];
+    const errors = [];
     if(!/^[a-z0-9]+$/.test(value)) {
       errors.push(
         new Error(
@@ -131,7 +131,7 @@ var descriptor = {
     return errors;
   }
 }
-var validator = new schema(descriptor);
+const validator = new schema(descriptor);
 validator.validate({name: "Firstname"}, (errors, fields) => {
   if(errors) {
     return handleErrors(errors, fields);
@@ -143,11 +143,11 @@ validator.validate({name: "Firstname"}, (errors, fields) => {
 It is often useful to test against multiple validation rules for a single field, to do so make the rule an array of objects, for example:
 
 ```javascript
-var descriptor = {
+const descriptor = {
   email: [
     {type: "string", required: true, pattern: schema.pattern.email},
     {validator(rule, value, callback, source, options) {
-      var errors = [];
+      const errors = [];
       // test if email address already exists in a database
       // and add a validation error to the errors array if it does
       return errors;
@@ -201,7 +201,7 @@ If the `len` property is combined with the `min` and `max` range properties, `le
 To validate a value from a list of possible values use the `enum` type with a `enum` property listing the valid values for the field, for example:
 
 ```javascript
-var descriptor = {
+const descriptor = {
   role: {type: "enum", enum: ['admin', 'user', 'guest']}
 }
 ```
@@ -218,7 +218,7 @@ You may wish to sanitize user input instead of testing for whitespace, see [tran
 If you need to validate deep object properties you may do so for validation rules that are of the `object` or `array` type by assigning nested rules to a `fields` property of the rule.
 
 ```javascript
-var descriptor = {
+const descriptor = {
   address: {
     type: "object", required: true,
     fields: {
@@ -229,7 +229,7 @@ var descriptor = {
   },
   name: {type: "string", required: true}
 }
-var validator = new schema(descriptor);
+const validator = new schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
   // errors for address.street, address.city, address.zip
 });
@@ -240,7 +240,7 @@ Note that if you do not specify the `required` property on the parent rule it is
 Deep rule validation creates a schema for the nested rules so you can also specify the `options` passed to the `schema.validate()` method.
 
 ```javascript
-var descriptor = {
+const descriptor = {
   address: {
     type: "object", required: true, options: {first: true},
     fields: {
@@ -251,7 +251,7 @@ var descriptor = {
   },
   name: {type: "string", required: true}
 }
-var validator = new schema(descriptor);
+const validator = new schema(descriptor);
 
 validator.validate({ address: {} })
   .catch(({ errors, fields }) => {
@@ -262,7 +262,7 @@ validator.validate({ address: {} })
 The parent rule is also validated so if you have a set of rules such as:
 
 ```javascript
-var descriptor = {
+const descriptor = {
   roles: {
     type: "array", required: true, len: 3,
     fields: {
@@ -282,7 +282,7 @@ The `defaultField` property can be used with the `array` or `object` type for va
 It may be an `object` or `array` containing validation rules. For example:
 
 ```javascript
-var descriptor = {
+const descriptor = {
   urls: {
     type: "array", required: true,
     defaultField: {type: "url"}
@@ -298,7 +298,7 @@ Sometimes it is necessary to transform a value before validation, possibly to co
 
 ```javascript
 import schema from 'async-validator';
-var descriptor = {
+const descriptor = {
   name: {
     type: "string",
     required: true, pattern: /^[a-z]+$/,
@@ -307,8 +307,8 @@ var descriptor = {
     }
   }
 }
-var validator = new schema(descriptor);
-var source = {name: " user  "};
+const validator = new schema(descriptor);
+const source = {name: " user  "};
 validator.validate(source)
   .then(() => assert.equal(source.name, "user"));
 ```
@@ -343,11 +343,11 @@ In this scenario you could just provide your own messages for the language and a
 
 ```javascript
 import schema from 'async-validator';
-var cn = {
+const cn = {
   required: '%s 必填',
 };
-var descriptor = {name:{type: "string", required: true}};
-var validator = new schema(descriptor);
+const descriptor = {name:{type: "string", required: true}};
+const validator = new schema(descriptor);
 // deep merge with defaultMessages
 validator.messages(cn);
 ...

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ const fields = {
 
 #### validator
 
-you can custom validate function for specified field:
+You can custom validate function for specified field:
 
 ```js
 const fields = {
@@ -449,7 +449,7 @@ npm run chrome-test
 npm run coverage
 ```
 
-open coverage/ dir
+Open coverage/ dir
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ import Schema from 'async-validator';
 const descriptor = {
   name: {
     type: 'string',
-    required: true, pattern: /^[a-z]+$/,
+    required: true,
+    pattern: /^[a-z]+$/,
     transform(value) {
       return value.trim();
     }

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ If you need to validate deep object properties you may do so for validation rule
 ```js
 const descriptor = {
   address: {
-    type: 'object', required: true,
+    type: 'object',
+    required: true,
     fields: {
       street: { type: 'string', required: true },
       city: { type: 'string', required: true },
@@ -242,7 +243,9 @@ Deep rule validation creates a schema for the nested rules so you can also speci
 ```js
 const descriptor = {
   address: {
-    type: 'object', required: true, options: { first: true },
+    type: 'object',
+    required: true,
+    options: { first: true },
     fields: {
       street: { type: 'string', required: true },
       city: { type: 'string', required: true },
@@ -264,7 +267,9 @@ The parent rule is also validated so if you have a set of rules such as:
 ```js
 const descriptor = {
   roles: {
-    type: 'array', required: true, len: 3,
+    type: 'array',
+    required: true,
+    len: 3,
     fields: {
       0: { type: 'string', required: true },
       1: { type: 'string', required: true },
@@ -284,7 +289,8 @@ It may be an `object` or `array` containing validation rules. For example:
 ```js
 const descriptor = {
   urls: {
-    type: 'array', required: true,
+    type: 'array',
+    required: true,
     defaultField: { type: 'url' }
   }
 };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # async-validator
----
-
-Validate form asynchronous. A variation of https://github.com/freeformsystems/async-validate
 
 [![NPM version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
@@ -22,6 +19,8 @@ Validate form asynchronous. A variation of https://github.com/freeformsystems/as
 [download-url]: https://npmjs.org/package/async-validator
 [bundlesize-image]: https://img.shields.io/bundlephobia/minzip/async-validator.svg?label=gzip%20size
 [bundlesize-url]: https://bundlephobia.com/result?p=async-validator
+
+Validate form asynchronous. A variation of https://github.com/freeformsystems/async-validate
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm i async-validator
 Basic usage involves defining a descriptor, assigning it to a schema and passing the object to be validated and a callback function to the `validate` method of the schema:
 
 ```js
-import schema from 'async-validator';
+import Schema from 'async-validator';
 const descriptor = {
   name: {
     type: 'string',
@@ -54,7 +54,7 @@ const descriptor = {
     }
   }
 };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 validator.validate({ name: 'muji' }, (errors, fields) => {
   if (errors) {
     // validation failed, errors is an array of all errors
@@ -118,7 +118,7 @@ function(rule, value, callback, source, options)
 The options passed to `validate` or `asyncValidate` are passed on to the validation functions so that you may reference transient data (such as model references) in validation functions. However, some option names are reserved; if you use these properties of the options object they are overwritten. The reserved properties are `messages`, `exception` and `error`.
 
 ```js
-import schema from 'async-validator';
+import Schema from 'async-validator';
 const descriptor = {
   name(rule, value, callback, source, options) {
     const errors = [];
@@ -131,7 +131,7 @@ const descriptor = {
     return errors;
   }
 };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 validator.validate({ name: 'Firstname' }, (errors, fields) => {
   if (errors) {
     return handleErrors(errors, fields);
@@ -145,7 +145,7 @@ It is often useful to test against multiple validation rules for a single field,
 ```js
 const descriptor = {
   email: [
-    { type: 'string', required: true, pattern: schema.pattern.email },
+    { type: 'string', required: true, pattern: Schema.pattern.email },
     { 
       validator(rule, value, callback, source, options) {
         const errors = [];
@@ -231,7 +231,7 @@ const descriptor = {
   },
   name: { type: 'string', required: true }
 };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
   // errors for address.street, address.city, address.zip
 });
@@ -253,7 +253,7 @@ const descriptor = {
   },
   name: { type: 'string', required: true }
 };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 
 validator.validate({ address: {} })
   .catch(({ errors, fields }) => {
@@ -299,7 +299,7 @@ Note that `defaultField` is expanded to `fields`, see [deep rules](#deep-rules).
 Sometimes it is necessary to transform a value before validation, possibly to coerce the value or to sanitize it in some way. To do this add a `transform` function to the validation rule. The property is transformed prior to validation and re-assigned to the source object to mutate the value of the property in place.
 
 ```js
-import schema from 'async-validator';
+import Schema from 'async-validator';
 const descriptor = {
   name: {
     type: 'string',
@@ -309,7 +309,7 @@ const descriptor = {
     }
   }
 };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 const source = { name: ' user  ' };
 validator.validate(source)
   .then(() => assert.equal(source.name, 'user'));
@@ -344,12 +344,12 @@ Potentially you may require the same schema validation rules for different langu
 In this scenario you could just provide your own messages for the language and assign it to the schema:
 
 ```js
-import schema from 'async-validator';
+import Schema from 'async-validator';
 const cn = {
   required: '%s 必填',
 };
 const descriptor = { name: { type: 'string', required: true } };
-const validator = new schema(descriptor);
+const validator = new Schema(descriptor);
 // deep merge with defaultMessages
 validator.messages(cn);
 ...

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ validator.validate({ name: 'muji', age: 16 }).then(() => {
   // validation passed or without error message
 }).catch(({ errors, fields }) => {
   return handleErrors(errors, fields);
-})
+});
 ```
 
 ## API
@@ -130,7 +130,7 @@ const descriptor = {
     }
     return errors;
   }
-}
+};
 const validator = new schema(descriptor);
 validator.validate({ name: 'Firstname' }, (errors, fields) => {
   if (errors) {
@@ -155,7 +155,7 @@ const descriptor = {
       }
     }
   ]
-}
+};
 ```
 
 #### Type
@@ -205,7 +205,7 @@ To validate a value from a list of possible values use the `enum` type with a `e
 ```js
 const descriptor = {
   role: { type: 'enum', enum: ['admin', 'user', 'guest'] }
-}
+};
 ```
 
 #### Whitespace
@@ -230,7 +230,7 @@ const descriptor = {
     }
   },
   name: { type: 'string', required: true }
-}
+};
 const validator = new schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
   // errors for address.street, address.city, address.zip
@@ -252,7 +252,7 @@ const descriptor = {
     }
   },
   name: { type: 'string', required: true }
-}
+};
 const validator = new schema(descriptor);
 
 validator.validate({ address: {} })
@@ -273,7 +273,7 @@ const descriptor = {
       2: { type: 'string', required: true }
     }
   }
-}
+};
 ```
 
 And supply a source object of `{ roles: ['admin', 'user'] }` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
@@ -289,7 +289,7 @@ const descriptor = {
     type: 'array', required: true,
     defaultField: { type: 'url' }
   }
-}
+};
 ```
 
 Note that `defaultField` is expanded to `fields`, see [deep rules](#deep-rules).
@@ -308,7 +308,7 @@ const descriptor = {
       return value.trim();
     }
   }
-}
+};
 const validator = new schema(descriptor);
 const source = { name: ' user  ' };
 validator.validate(source)

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ const fields = {
 
   field2: {
     validator(rule, value, callback) {
-      return new Error(`'${value} is not equal to "test".'`);
+      return new Error(`${value} is not equal to 'test'.`);
     },
   },
  

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ const descriptor = {
           resolve();
         }
       });
-    }
-  }
+    },
+  },
 };
 const validator = new Schema(descriptor);
 validator.validate({ name: 'muji' }, (errors, fields) => {
@@ -127,7 +127,7 @@ const descriptor = {
       ));
     }
     return errors;
-  }
+  },
 };
 const validator = new Schema(descriptor);
 validator.validate({ name: 'Firstname' }, (errors, fields) => {
@@ -150,9 +150,9 @@ const descriptor = {
         // test if email address already exists in a database
         // and add a validation error to the errors array if it does
         return errors;
-      }
-    }
-  ]
+      },
+    },
+  ],
 };
 ```
 
@@ -202,7 +202,7 @@ To validate a value from a list of possible values use the `enum` type with a `e
 
 ```js
 const descriptor = {
-  role: { type: 'enum', enum: ['admin', 'user', 'guest'] }
+  role: { type: 'enum', enum: ['admin', 'user', 'guest'] },
 };
 ```
 
@@ -225,10 +225,10 @@ const descriptor = {
     fields: {
       street: { type: 'string', required: true },
       city: { type: 'string', required: true },
-      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' }
-    }
+      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' },
+    },
   },
-  name: { type: 'string', required: true }
+  name: { type: 'string', required: true },
 };
 const validator = new Schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
@@ -249,10 +249,10 @@ const descriptor = {
     fields: {
       street: { type: 'string', required: true },
       city: { type: 'string', required: true },
-      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' }
-    }
+      zip: { type: 'string', required: true, len: 8, message: 'invalid zip' },
+    },
   },
-  name: { type: 'string', required: true }
+  name: { type: 'string', required: true },
 };
 const validator = new Schema(descriptor);
 
@@ -273,9 +273,9 @@ const descriptor = {
     fields: {
       0: { type: 'string', required: true },
       1: { type: 'string', required: true },
-      2: { type: 'string', required: true }
-    }
-  }
+      2: { type: 'string', required: true },
+    },
+  },
 };
 ```
 
@@ -291,8 +291,8 @@ const descriptor = {
   urls: {
     type: 'array',
     required: true,
-    defaultField: { type: 'url' }
-  }
+    defaultField: { type: 'url' },
+  },
 };
 ```
 
@@ -311,8 +311,8 @@ const descriptor = {
     pattern: /^[a-z]+$/,
     transform(value) {
       return value.trim();
-    }
-  }
+    },
+  },
 };
 const validator = new Schema(descriptor);
 const source = { name: ' user  ' };
@@ -372,23 +372,23 @@ const fields = {
     asyncValidator(rule, value, callback) {
       ajax({
         url: 'xx',
-        value: value
+        value: value,
       }).then(function(data) {
         callback();
       }, function(error) {
-        callback(new Error(error))
+        callback(new Error(error));
       });
-    }
+    },
   },
 
   promiseField: {
     asyncValidator(rule, value) {
       return ajax({
         url: 'xx',
-        value: value
+        value: value,
       });
-    }
-  }
+    },
+  },
 };
 ```
 
@@ -417,7 +417,7 @@ const fields = {
         new Error('Message 1'),
         new Error('Message 2'),
       ];
-    }
+    },
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ Basic usage involves defining a descriptor, assigning it to a schema and passing
 import schema from 'async-validator';
 const descriptor = {
   name: {
-    type: "string",
+    type: 'string',
     required: true,
     validator: (rule, value) => value === 'muji',
   },
   age: {
-    type: "number",
+    type: 'number',
     asyncValidator: (rule, value) => {
         return new Promise((resolve, reject) => {
           if (value < 18) {
-            reject("too young");  // reject with error message
+            reject('too young');  // reject with error message
           } else {
             resolve();
           }
@@ -55,7 +55,7 @@ const descriptor = {
   }
 };
 const validator = new schema(descriptor);
-validator.validate({name: "muji"}, (errors, fields) => {
+validator.validate({name: 'muji'}, (errors, fields) => {
   if(errors) {
     // validation failed, errors is an array of all errors
     // fields is an object keyed by field name with an array of
@@ -66,7 +66,7 @@ validator.validate({name: "muji"}, (errors, fields) => {
 });
 
 // PROMISE USAGE
-validator.validate({ name: "muji", age: 16 }).then(() => {
+validator.validate({ name: 'muji', age: 16 }).then(() => {
   // validation passed or without error message
 }).catch(({ errors, fields }) => {
   return handleErrors(errors, fields);
@@ -125,14 +125,14 @@ const descriptor = {
     if(!/^[a-z0-9]+$/.test(value)) {
       errors.push(
         new Error(
-          util.format("%s must be lowercase alphanumeric characters",
+          util.format('%s must be lowercase alphanumeric characters',
             rule.field)));
     }
     return errors;
   }
 }
 const validator = new schema(descriptor);
-validator.validate({name: "Firstname"}, (errors, fields) => {
+validator.validate({name: 'Firstname'}, (errors, fields) => {
   if(errors) {
     return handleErrors(errors, fields);
   }
@@ -145,7 +145,7 @@ It is often useful to test against multiple validation rules for a single field,
 ```js
 const descriptor = {
   email: [
-    {type: "string", required: true, pattern: schema.pattern.email},
+    {type: 'string', required: true, pattern: schema.pattern.email},
     {validator(rule, value, callback, source, options) {
       const errors = [];
       // test if email address already exists in a database
@@ -202,7 +202,7 @@ To validate a value from a list of possible values use the `enum` type with a `e
 
 ```js
 const descriptor = {
-  role: {type: "enum", enum: ['admin', 'user', 'guest']}
+  role: {type: 'enum', enum: ['admin', 'user', 'guest']}
 }
 ```
 
@@ -220,14 +220,14 @@ If you need to validate deep object properties you may do so for validation rule
 ```js
 const descriptor = {
   address: {
-    type: "object", required: true,
+    type: 'object', required: true,
     fields: {
-      street: {type: "string", required: true},
-      city: {type: "string", required: true},
-      zip: {type: "string", required: true, len: 8, message: "invalid zip"}
+      street: {type: 'string', required: true},
+      city: {type: 'string', required: true},
+      zip: {type: 'string', required: true, len: 8, message: 'invalid zip'}
     }
   },
-  name: {type: "string", required: true}
+  name: {type: 'string', required: true}
 }
 const validator = new schema(descriptor);
 validator.validate({ address: {} }, (errors, fields) => {
@@ -242,14 +242,14 @@ Deep rule validation creates a schema for the nested rules so you can also speci
 ```js
 const descriptor = {
   address: {
-    type: "object", required: true, options: {first: true},
+    type: 'object', required: true, options: {first: true},
     fields: {
-      street: {type: "string", required: true},
-      city: {type: "string", required: true},
-      zip: {type: "string", required: true, len: 8, message: "invalid zip"}
+      street: {type: 'string', required: true},
+      city: {type: 'string', required: true},
+      zip: {type: 'string', required: true, len: 8, message: 'invalid zip'}
     }
   },
-  name: {type: "string", required: true}
+  name: {type: 'string', required: true}
 }
 const validator = new schema(descriptor);
 
@@ -264,17 +264,17 @@ The parent rule is also validated so if you have a set of rules such as:
 ```js
 const descriptor = {
   roles: {
-    type: "array", required: true, len: 3,
+    type: 'array', required: true, len: 3,
     fields: {
-      0: {type: "string", required: true},
-      1: {type: "string", required: true},
-      2: {type: "string", required: true}
+      0: {type: 'string', required: true},
+      1: {type: 'string', required: true},
+      2: {type: 'string', required: true}
     }
   }
 }
 ```
 
-And supply a source object of `{roles: ["admin", "user"]}` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
+And supply a source object of `{roles: ['admin', 'user']}` then two errors will be created. One for the array length mismatch and one for the missing required array entry at index 2.
 
 #### defaultField
 
@@ -284,8 +284,8 @@ It may be an `object` or `array` containing validation rules. For example:
 ```js
 const descriptor = {
   urls: {
-    type: "array", required: true,
-    defaultField: {type: "url"}
+    type: 'array', required: true,
+    defaultField: {type: 'url'}
   }
 }
 ```
@@ -300,7 +300,7 @@ Sometimes it is necessary to transform a value before validation, possibly to co
 import schema from 'async-validator';
 const descriptor = {
   name: {
-    type: "string",
+    type: 'string',
     required: true, pattern: /^[a-z]+$/,
     transform(value) {
       return value.trim();
@@ -308,9 +308,9 @@ const descriptor = {
   }
 }
 const validator = new schema(descriptor);
-const source = {name: " user  "};
+const source = {name: ' user  '};
 validator.validate(source)
-  .then(() => assert.equal(source.name, "user"));
+  .then(() => assert.equal(source.name, 'user'));
 ```
 
 Without the `transform` function validation would fail due to the pattern not matching as the input contains leading and trailing whitespace, but by adding the transform function validation passes and the field value is sanitized at the same time.
@@ -323,18 +323,18 @@ Depending upon your application requirements, you may need i18n support or you m
 The easiest way to achieve this is to assign a `message` to a rule:
 
 ```js
-{name:{type: "string", required: true, message: "Name is required"}}
+{name:{type: 'string', required: true, message: 'Name is required'}}
 ```
 
 Message can be any type, such as jsx format.
 
 ```js
-{name:{type: "string", required: true, message: "<b>Name is required</b>"}}
+{name:{type: 'string', required: true, message: '<b>Name is required</b>'}}
 ```
 
 Message can also be a function, e.g. if you use vue-i18n:
 ```js
-{name:{type: "string", required: true, message: () => this.$t( 'name is required' )}}
+{name:{type: 'string', required: true, message: () => this.$t( 'name is required' )}}
 ```
 
 Potentially you may require the same schema validation rules for different languages, in which case duplicating the schema rules for each language does not make sense.
@@ -346,7 +346,7 @@ import schema from 'async-validator';
 const cn = {
   required: '%s 必填',
 };
-const descriptor = {name:{type: "string", required: true}};
+const descriptor = {name:{type: 'string', required: true}};
 const validator = new schema(descriptor);
 // deep merge with defaultMessages
 validator.messages(cn);


### PR DESCRIPTION
Updates:
- replace var with const
- capitalized sentences
- set and unify headers for code
- replace double quotes with single quotes
- add spaces for code unification
- remove and add padding
- set semicolon at the end of instructions
- rename schema class to Schema
- remove extra quotes
- add line feed between object parameters
- move items in a header by importance
- format multiline example
- add trailing comma