### PR TITLE
fix: fix test error for #246

### DIFF
--- a/src/rule/type.js
+++ b/src/rule/type.js
@@ -34,11 +34,7 @@ const types = {
     }
   },
   date(value) {
-    return (
-      typeof value.getTime === 'function' &&
-      typeof value.getMonth === 'function' &&
-      typeof value.getYear === 'function'
-    );
+    return value.toString() !== 'Invalid Date';
   },
   number(value) {
     if (isNaN(value)) {


### PR DESCRIPTION
Now dateObject will always be a Date instance, so the judgment here needs to be changed.

for: https://github.com/yiminghe/async-validator/pull/246