### PR TITLE
fix: `message` should work when its empty string

### DIFF
--- a/__tests__/required.spec.js
+++ b/__tests__/required.spec.js
@@ -188,4 +188,22 @@ describe('required', () => {
       },
     );
   });
+
+  it('should support empty string message', done => {
+    new Schema({
+      v: {
+        required,
+        message: '',
+      },
+    }).validate(
+      {
+        v: '',
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('');
+        done();
+      },
+    );
+  });
 });

--- a/__tests__/validator.spec.js
+++ b/__tests__/validator.spec.js
@@ -44,19 +44,27 @@ describe('validator', () => {
             return true;
           },
         },
+        // Customize with empty message
+        {
+          validator() {
+            return false;
+          },
+          message: '',
+        },
       ],
     }).validate(
       {
         v: 2,
       },
       errors => {
-        expect(errors.length).toBe(6);
+        expect(errors.length).toBe(7);
         expect(errors[0].message).toBe('e1');
         expect(errors[1].message).toBe('e2');
         expect(errors[2].message).toBe('e3');
         expect(errors[3].message).toBe('v3 fails');
         expect(errors[4].message).toBe('e5');
         expect(errors[5].message).toBe('e6');
+        expect(errors[6].message).toBe('');
         done();
       },
     );

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ Schema.prototype = {
           if (!options.suppressWarning && errors.length) {
             Schema.warning('async-validator:', errors);
           }
-          if (errors.length && rule.message) {
+          if (errors.length && rule.message !== undefined) {
             errors = [].concat(rule.message);
           }
 
@@ -178,7 +178,7 @@ Schema.prototype = {
             // does not exist fail at the rule level and don't
             // go deeper
             if (rule.required && !data.value) {
-              if (rule.message) {
+              if (rule.message !== undefined) {
                 errors = [].concat(rule.message).map(complementError(rule));
               } else if (options.error) {
                 errors = [
@@ -263,7 +263,8 @@ Schema.prototype = {
     }
     if (
       typeof rule.validator !== 'function' &&
-      rule.type && !validators.hasOwnProperty(rule.type)
+      rule.type &&
+      !validators.hasOwnProperty(rule.type)
     ) {
       throw new Error(format('Unknown rule type %s', rule.type));
     }
@@ -299,6 +300,5 @@ Schema.warning = warning;
 Schema.messages = defaultMessages;
 
 Schema.validators = validators;
-
 
 export default Schema;


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/27697