### PR TITLE
fix: [] should be validated by min and max

### DIFF
--- a/__tests__/array.spec.js
+++ b/__tests__/array.spec.js
@@ -123,4 +123,42 @@ describe('array', () => {
       },
     );
   });
+
+  it('works for empty array with min', done => {
+    new Schema({
+      v: {
+        min: 1,
+        max: 3,
+        type: 'array',
+      },
+    }).validate(
+      {
+        v: [],
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('v must be between 1 and 3 in length');
+        done();
+      },
+    );
+  });
+
+  it('works for empty array with max', done => {
+    new Schema({
+      v: {
+        min: 1,
+        max: 3,
+        type: 'array',
+      },
+    }).validate(
+      {
+        v: [1, 2, 3, 4],
+      },
+      errors => {
+        expect(errors.length).toBe(1);
+        expect(errors[0].message).toBe('v must be between 1 and 3 in length');
+        done();
+      },
+    );
+  });
 });

--- a/src/validator/array.js
+++ b/src/validator/array.js
@@ -15,11 +15,11 @@ function array(rule, value, callback, source, options) {
   const validate =
     rule.required || (!rule.required && source.hasOwnProperty(rule.field));
   if (validate) {
-    if (isEmptyValue(value, 'array') && !rule.required) {
+    if ((value === undefined || value === null) && !rule.required) {
       return callback();
     }
     rules.required(rule, value, source, errors, options, 'array');
-    if (!isEmptyValue(value, 'array')) {
+    if (value !== undefined && value !== null) {
       rules.type(rule, value, source, errors, options);
       rules.range(rule, value, source, errors, options);
     }


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/27845

```jsx
        rules={[
          {
            type: "array",
            min: 1,
            max: 2,
            message: "Please input your choices!"
          }
        ]}
```

当 value 是 `[]` 时，目前的逻辑会直接不走 range 的判断逻辑，从而使 `min: 1` 的设置失效。