### PR TITLE
fix: support empty error

### DIFF
--- a/__tests__/promise.spec.ts
+++ b/__tests__/promise.spec.ts
@@ -174,6 +174,12 @@ describe('asyncValidator', () => {
                 setTimeout(() => reject(new Error('e6')), 100);
               }),
           },
+          {
+            asyncValidator: () =>
+              new Promise((resolve, reject) => {
+                setTimeout(() => reject(new Error('')), 100);
+              }),
+          },
         ],
       }).validate(
         {
@@ -185,12 +191,13 @@ describe('asyncValidator', () => {
           firstFields: ['v'],
         },
         errors => {
-          expect(errors.length).toBe(5);
+          expect(errors.length).toBe(6);
           expect(errors[0].message).toBe('e1');
           expect(errors[1].message).toBe('e3');
           expect(errors[2].message).toBe('e4');
           expect(errors[3].message).toBe('e5');
           expect(errors[4].message).toBe('e6');
+          expect(errors[5].message).toBe('');
           done();
         },
       );

--- a/src/util.ts
+++ b/src/util.ts
@@ -248,7 +248,7 @@ export function asyncMap(
 function isErrorObj(
   obj: ValidateError | string | (() => string),
 ): obj is ValidateError {
-  return !!(obj && (obj as ValidateError).message);
+  return !!(obj && (obj as ValidateError).message !== undefined);
 }
 
 function getValue(value: Values, path: string[]) {


### PR DESCRIPTION
Should not return Error directly when `new Error('')`.

ref: https://github.com/ant-design/ant-design/issues/31803