### PR TITLE
docs: callback parameter of validate function is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ function(source, [options], callback): Promise
 
 * `source`: The object to validate (required).
 * `options`: An object describing processing options for the validation (optional).
-* `callback`: A callback function to invoke when validation completes (required).
+* `callback`: A callback function to invoke when validation completes (optional).
 
 The method will return a Promise object like:
 * `then()`，validation passed


### PR DESCRIPTION
The `callback` parameter of `validate` function is optional, as:

```js
// PROMISE USAGE
validator.validate({ name: 'muji', age: 16 }).then(() => {
  // validation passed or without error message
}).catch(({ errors, fields }) => {
  return handleErrors(errors, fields);
});
```